### PR TITLE
make isDependent(src,dest) overridable from user code

### DIFF
--- a/src/intercooler.js
+++ b/src/intercooler.js
@@ -23,7 +23,11 @@ var Intercooler = Intercooler || (function () {
 
   var _UUID = 1;
 
-  //============================================================
+  var _isDependentFunction = function (src, dest) {
+      return (src && dest) && (dest.indexOf(src) == 0 || src.indexOf(dest) == 0);
+  };
+
+    //============================================================
   // Base Transition Definitions
   //============================================================
   var _transitions = {};
@@ -574,7 +578,7 @@ var Intercooler = Intercooler || (function () {
   }
 
   function isDependent(src, dest) {
-    return (src && dest) && (dest.indexOf(src) == 0 || src.indexOf(dest) == 0);
+    return _isDependentFunction(src, dest);
   }
 
   //============================================================----
@@ -905,7 +909,7 @@ var Intercooler = Intercooler || (function () {
       }
       return Intercooler;
     },
-    
+
     processNodes: function(elt) {
       return processNodes(elt);
     },
@@ -916,6 +920,10 @@ var Intercooler = Intercooler || (function () {
 
     defineTransition: function (name, def) {
       _defineTransition(name, def);
+    },
+
+    isDependentFunction: function (func) {
+        _isDependentFunction = func;
     },
 
     /* ===================================================


### PR DESCRIPTION
This makes the internal isDependent() overridable via `Intercooler.isDependentFunction = func(src, dest) { return bool; }`.

The point of this is that some users might want more fine-grained control over how URLs are matched against each other.

By default, Intercooler considers `/model/123` to be a dep of `/model/1`. This is a bit awkward, and might trigger multiple refreshes.

I'm using the attached patch to do this:

```
Intercooler.isDependentFunction (src, dest) ->
  unless src && dest
    return false

  sa = src.split("/")
  sd = dest.split("/")

  sd.slice(0, sa.length).join("/") == sa.join("/")
```

which basically checks that the individual path elements are equal, and not just the start of the string.

Not sure if this is something you'd want to consider.
