### PR TITLE
Allow pulling specific elements

### DIFF
--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -1,0 +1,1 @@
+((js-mode . ((js-indent-level . 2))))

--- a/www/attributes/ic-src.html
+++ b/www/attributes/ic-src.html
@@ -25,6 +25,9 @@ nav: attributes > ic-src
 
       <p>The value of the attribute should be a valid relative path (e.g. <code>ic-src="/foo/bar"</code>).</p>
 
+      <p>The value of the attribute may also include a <i>fragment identifier</i> (e.g. <code>ic-src="/foo#bar"</code>).
+      In this case, everything on the page except the element whose ID matches the fragment identifier is ignored.</p>
+
       <h3>Dependencies</h3>
 
       <p><code>ic-src</code> implies a dependency on its path, and Intercooler will issue requests for elements

--- a/www/dependencies.html
+++ b/www/dependencies.html
@@ -76,8 +76,18 @@ nav: dependencies
           <td>YES</td>
         </tr>
         <tr>
+          <td>/foo</td>
+          <td>/foo#bar</td>
+          <td>YES</td>
+        </tr>
+        <tr>
           <td>/foo/doh</td>
           <td>/foo/bar</td>
+          <td>NO</td>
+        </tr>
+        <tr>
+          <td>/foo#doh</td>
+          <td>/foo#bar</td>
           <td>NO</td>
         </tr>
         </tbody>

--- a/www/intro.html
+++ b/www/intro.html
@@ -29,7 +29,7 @@ nav: intro
       to, when to do so, and how to handle the responses from the server.  There are three core attributes:</p>
 
       <ul>
-        <li><a href="/attributes/ic-src.html"><code>ic-src</code></a> - <strong>Where</strong> to send and AJAX
+        <li><a href="/attributes/ic-src.html"><code>ic-src</code></a> - <strong>Where</strong> to send an AJAX
           request to (i.e. the path to submit to)</li>
         <li><a href="/attributes/ic-verb.html"><code>ic-verb</code></a>- <strong>What</strong>
           <a href="http://en.wikipedia.org/wiki/Hypertext_Transfer_Protocol#Request_methods">HTTP verb</a> to use for


### PR DESCRIPTION
These commits extend `ic-src` so you can reference a particular element on a page by using a fragment identifier. For example

    <span ic-src="foo#bar" ic-poll="2s"></span>

will poll only the element whose ID is `bar`. 

This should be useful for using Intercooler with existing sites, and for projects that observe progressive enhancement.

I also took the liberty of fixing a typo, and adding a `.dir-locals.el` file to the root directory to enforce your style of indentation for Emacs users.