### PR TITLE
Feature/local ref

### DIFF
--- a/src/intercooler.js
+++ b/src/intercooler.js
@@ -398,6 +398,46 @@ var Intercooler = Intercooler || (function () {
     })
   }
 
+  //============================================================
+  // local references transport jquery plugin
+  //============================================================
+  function localTransport(options, origOptions, jqXHR) {
+    var ltAttr="ic-lt-";
+    if (origOptions.url[0]=="#") {
+      var src=$(origOptions.url);
+      var rsphdr=[];
+      var status=200;
+      var statusText="OK";
+      src.each(function(i, el) {
+        $.each(el.attributes, function(j, attr) {
+          if (attr.name.substr(0,ltAttr.length) == ltAttr) {
+            var lhName=attr.name.substring(ltAttr.length);
+            if (lhName == "status") {
+              var statusLine=attr.value.match(/(\d+)\s?(.*)/);
+              if (statusLine != null) {
+                status=statusLine[1];
+                statusText=statusLine[2];
+              } else {
+                status="500";
+                statusText="Attribute Error";
+              }
+            } else {
+              rsphdr.push(lhName+": "+attr.value);
+            }
+          }
+        });
+      });
+      var rsp=src.length > 0 ? src.html() : "";
+      return {
+        send: function(reqhdr, completeCallback) {
+          completeCallback(status, statusText, {html: rsp}, rsphdr.join("\n"));
+        },
+        abort: function() {}
+      }
+    }
+  }
+  _remote.ajaxTransport("text",localTransport);
+
   function findIndicator(elt) {
     var indicator = null;
     if ($(elt).attr('ic-indicator')) {

--- a/www/examples/local-ref.html
+++ b/www/examples/local-ref.html
@@ -1,0 +1,35 @@
+<!doctype html>
+<html>
+<head>
+
+<!-- Latest compiled and minified CSS -->
+<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/css/bootstrap.min.css">
+<!-- Optional theme -->
+<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/css/bootstrap-theme.min.css">
+
+<script src="https://code.jquery.com/jquery-1.11.2.min.js"></script>
+<!-- Latest compiled and minified JavaScript -->
+<script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/js/bootstrap.min.js"></script>
+
+<script src="/src/intercooler.js"></script>
+</head>
+<body>
+
+<div class="container">
+
+ <div ic-on-error="alert('oh no!')">
+   <div class="btn btn-default" ic-get-from="#storage .hw">Click me</div>
+   <div class="btn btn-default" ic-get-from="#storage .gw" ic-transition="none">Don't Click me</div>
+  </div>
+
+</div>
+
+<div id="storage" style="display: none">
+  <div class="hw">Hello, world</div>
+  <div class="gw" ic-lt-status="500 Server Error">Goodbye, world</div>
+</div>
+
+</body>
+</html>
+
+


### PR DESCRIPTION
Adding in the local transport plugin.

After considering how to make the 'local reference' addresses work without using a jquery transport plugin, it would have been much more complicated to get all the surrounding functionality to work - pre/post hooks, dependencies, etc - if it was done as a non-network request.  So the plugin is the easiest route; I just pulled in my other version with a minimum of changes.

This code only recognizes a url starting with "#" as a local reference and not a specific url scheme, i.e., it must address an id selector.  

The response headers for a local reference are any attributes starting "ic-lt-" so that standard intercooler response headers can be specified.  "ic-lt-status" is also recognized as the http response code, so a value of "500 error" will trigger ic-on-error handlers.


