### PR TITLE
fix isDependant() resulting in unwarranted reloads, expose over API

### DIFF
--- a/test/unit_tests.html
+++ b/test/unit_tests.html
@@ -357,6 +357,26 @@
   });
 </script>
 
+<script>
+  intercoolerTest("partial path elements do not indicate a dependency", function (assert) {
+    assert.ok(!Intercooler.isDependent("/model/aa", "/model/a"));
+    assert.ok(!Intercooler.isDependent("/model/a", "/model/aa"));
+  }, function(assert) {});
+</script>
+
+<script>
+  intercoolerTest("query string and hash arguments are stripped for dependency checks", function (assert) {
+    assert.ok(Intercooler.isDependent("/model/aa?1", "/model/aa?2"));
+    assert.ok(Intercooler.isDependent("/model/#1", "/model/#2"));
+  }, function(assert) {});
+</script>
+
+<script>
+  intercoolerTest("empty path elements are discarded for isDependent", function (assert) {
+    assert.ok(Intercooler.isDependent("/model/1", "//model//1/"));
+  }, function(assert) {});
+</script>
+
 <div id="ic-deps-div1" ic-src="/deps_test4" ic-deps="/deps_test5">Foo</div>
 <button id="ic-deps-btn1" ic-post-to="/deps_test5">Clicked</button>
 <script>


### PR DESCRIPTION
The original isDependant() function would only compare strings; so
/a/123 would be dep of /a/12. This isn't what users want!

This implementation fixes that by comparing individual path elements,
after stripping off hash arguments and query string.

It also exposes the function over the global API object so people can
plug in their own impl, in case their framework is laid out differently;
while not a very often-used feature it might be neccessary for some
clientside javascript frameworks that store route information in a hasharg.

--

Okay, so this is a weeee bit late (#23!). But let me re-alive this anyways!

Here's the implementation and test cases as far as I could make the test framework work locally (it sometimes fails tests and a reload fixes them!).

Note that the implementation uses filter(), which is a JS 1.6 feature. If you think that's a problem, I'll amend.

Cheers!