### PR TITLE
Remove www folder from Bower package.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -12,7 +12,8 @@
     "*.md",
     "AUTHORS.txt",
     "Gruntfile.js",
-    "package.json"
+    "package.json",
+    "www"
   ],
   "keywords": [
     "intercooler",


### PR DESCRIPTION
As far as I know, there's no need for this folder to be included with bower. You already get rid of a bunch of non-production files, including the test files, so the www folder likely ought to be included in that, no?