### PR TITLE
Add an event once the swap is done.

### DIFF
--- a/src/intercooler.js
+++ b/src/intercooler.js
@@ -1226,6 +1226,7 @@ var Intercooler = Intercooler || (function() {
       setTimeout(function() {
         try {
           doSwap();
+          target.trigger('afterSwap.ic');
         } catch (e) {
           log(elt, "Error during content swaop : " + formatError(e), "ERROR");
         }


### PR DESCRIPTION
This is needed in the case where you need to re-initialise date-pickers etc. As the swap is in a timeout, even with zero delay you cannot target the event. 

Alternative is to put it in a custom timeout but better if it's triggered from here.