### PR TITLE
Add safe evaluation for user-supplied scripts

### DIFF
--- a/src/intercooler.js
+++ b/src/intercooler.js
@@ -241,7 +241,7 @@ var Intercooler = Intercooler || (function() {
 
     if (xhr.getResponseHeader("X-IC-Script")) {
       log(elt, "X-IC-Script: evaling " + xhr.getResponseHeader("X-IC-Script"), "DEBUG");
-      eval(xhr.getResponseHeader("X-IC-Script"));
+      globalEval(xhr.getResponseHeader("X-IC-Script"));
     }
 
     if (xhr.getResponseHeader("X-IC-Redirect")) {
@@ -352,8 +352,43 @@ var Intercooler = Intercooler || (function() {
     }
   }
 
-  function globalEval(script) {
-    return window["eval"].call(window, script);
+  /*
+    Is the provided text a valid JavaScript identifier path?
+
+    We should also probably check if an identifier is a JavaScript keyword here.
+  */
+  function isIdentifier(txt) {
+    return /^[$A-Z_][0-9A-Z_$]*$/i.test(txt);
+  }
+
+  /*
+    Evaluate a script snippet provided by the user.
+
+    script: A string. If this is an identifier, it is assumed to be a callable, retrieved from the
+    global namespace, and called. If it is a compound statement, it is evaluated using eval.
+    args: A list of [name, value] tuples. These will be injected into the namespace of evaluated
+    scripts, and be passed as arguments to safe evaluations.
+  */
+  // It would be nice to use the spread operator here globalEval(script, ...args) - but it breaks
+  // uglify and isn't supported in some older browsers.
+  function globalEval(script, args) {
+    var names = [];
+    var values = [];
+    if (args) {
+        for (var i = 0; i < args.length; i++) {
+            names.push(args[i][0]);
+            values.push(args[i][1]);
+        }
+    }
+    if (isIdentifier(script)) {
+        return window[script].apply(this, values);
+    } else {
+        var outerfunc  = window["eval"].call(
+            window,
+            '(function (' + names.join(", ") + ') {' + script + '})'
+        );
+        return outerfunc.apply(this, values);
+    }
   }
 
   function closestAttrValue(elt, attr) {
@@ -411,7 +446,7 @@ var Intercooler = Intercooler || (function() {
         log(elt, "before AJAX request " + requestId + ": " + type + " to " + url, "DEBUG");
         var onBeforeSend = closestAttrValue(elt, 'ic-on-beforeSend');
         if (onBeforeSend) {
-          globalEval('(function (data, settings, xhr) {' + onBeforeSend + '})')(data, settings, xhr);
+          globalEval(onBeforeSend, [["data", data], ["settings", settings], ["xhr", xhr]]);
         }
       },
       success: function(data, textStatus, xhr) {
@@ -419,7 +454,7 @@ var Intercooler = Intercooler || (function() {
         log(elt, "AJAX request " + requestId + " was successful.", "DEBUG");
         var onSuccess = closestAttrValue(elt, 'ic-on-success');
         if (onSuccess) {
-          if (globalEval('(function (data, textStatus, xhr) {' + onSuccess + '})')(data, textStatus, xhr) == false) {
+          if (globalEval(onSuccess, [["data", data], ["textStatus", textStatus], ["xhr", xhr]]) == false) {
             return;
           }
         }
@@ -457,7 +492,7 @@ var Intercooler = Intercooler || (function() {
         elt.trigger("error.ic", [elt, status, str, xhr]);
         var onError = closestAttrValue(elt, 'ic-on-error');
         if (onError) {
-          globalEval('(function (status, str, xhr) {' + onError + '})')(status, str, xhr);
+          globalEval(onError, [["status", status], ["str", str], ["xhr", xhr]]);
         }
         processHeaders(elt, xhr);
         log(elt, "AJAX request " + requestId + " to " + url + " experienced an error: " + str, "ERROR");
@@ -476,7 +511,7 @@ var Intercooler = Intercooler || (function() {
         }
         var onComplete = closestAttrValue(elt, 'ic-on-complete');
         if (onComplete) {
-          globalEval('(function (xhr, status) {' + onComplete + '})')(xhr, status);
+          globalEval(onError, [["xhr", xhr], ["status", status]]);
         }
       }
     };
@@ -966,8 +1001,10 @@ var Intercooler = Intercooler || (function() {
   function getTriggeredElement(elt) {
     var triggerFrom = getICAttribute(elt, 'ic-trigger-from');
     if(triggerFrom) {
-      if($.inArray(triggerFrom, ['document', 'window']) >= 0){
-        return $(eval(triggerFrom));
+      if (triggerFrom == "document") {
+        return $(document);
+      } else if (triggerFrom == "window") {
+        return $(window);
       } else {
         return $(triggerFrom);
       }
@@ -998,7 +1035,7 @@ var Intercooler = Intercooler || (function() {
 
             var onBeforeTrigger = closestAttrValue(elt, 'ic-on-beforeTrigger');
             if (onBeforeTrigger) {
-              if (globalEval('(function (evt, elt) {' + onBeforeTrigger + '})')(e, elt) == false) {
+              if (globalEval(onError, [["evt", e], ["elt", elt]]) == false) {
                 log(elt, "ic-trigger cancelled by ic-on-beforeTrigger", "DEBUG");
                 return false;
               }
@@ -1753,7 +1790,8 @@ var Intercooler = Intercooler || (function() {
       replaceOrAddMethod: replaceOrAddMethod,
       initEventSource: function(url) {
         return new EventSource(url);
-      }
+      },
+      globalEval: globalEval
     }
   };
 })();

--- a/test/unit_tests.html
+++ b/test/unit_tests.html
@@ -212,6 +212,38 @@
   </div>
 </div>
 
+<script>
+function eval_test(...args) {
+    return args;
+}
+QUnit.test("Script evaluation", function (assert) {
+  var geval = Intercooler._internal.globalEval;
+  assert.deepEqual(geval("return eval_test()"), [], "Unsafe basic: empty return");
+  assert.deepEqual(geval("return eval_test('a')"), ['a'], "Unsafe basic: return");
+  assert.deepEqual(
+    geval("return a", [['a', 'b']]),
+    "b",
+    "Unsafe args: single return"
+  );
+  assert.deepEqual(
+    geval("return [a, c]", [['a', 'b'], ['c', 'd']]),
+    ["b", "d"],
+    "Unsafe args: multiple return"
+  );
+  assert.deepEqual(geval("eval_test"), [], "Safe: empty return");
+  assert.deepEqual(
+    geval("eval_test", [['a', 'b']]),
+    ["b"],
+    "Safe args: single return"
+  );
+  assert.deepEqual(
+    geval("eval_test", [['a', 'b'], ['c', 'd']]),
+    ["b", "d"],
+    "Safe args: single return"
+  );
+});
+</script>
+
 <div class="row">
   <div class="col-md-12">
     <hr/>
@@ -223,6 +255,7 @@
     </script>
   </div>
 </div>
+
 
 <div id="ic-src-div2" ic-src="/basic_update">Foo</div>
 <script>


### PR DESCRIPTION
This implements my suggestion in #160. I'm using this version in the project I'm working on, and it effectively addresses the CSP and safety concerns I have. 

Future work:

- After this, the only remaining unsafe eval is in the handling of ic-action-target, which is a more complex case. I don't use this at the moment, so I haven't had to make this safe just yet. 
- At the moment, this only supports simple identifiers. This should probably be expanded to allow period-separated identifier paths, as suggested in #160. 
- I think a strict-safety mode for intercooler that completely disallows eval would be good to have.
- I think the semantics of the various script evaluation contexts needs to be clarified in the docs. Safe evaluations are now called with arguments matching those injected into the namespace for unsafe evaluations. This would also be an opportunity to expand arguments to include, for instance, the triggering element everywhere (which would let me generalise many of my functions). 

----


When a user-supplied script is a simple identifier (e.g. "my_function"), it is
assumed to be a callable, looked up in the global namespace, and invoked safely
without an eval(). Variables that would have been injected into the code's
namespace in unsafe evaluation are passed as arguments.

If the user-supplied script is compound or an invocation, the semantics remain
the same.

The patch also:

- Makes nearly all evaluation calls use globalEval
- Changes the ic-trigger-from mechanism to avoid using eval (it doesn't need it)
- Parameterises globalEval to avoid ad-hoc fuction strings in code,
and allow us to access arguments for safe evaluation