### PR TITLE
Clear last clicked button on select

### DIFF
--- a/src/intercooler.js
+++ b/src/intercooler.js
@@ -1056,7 +1056,7 @@ var Intercooler = Intercooler || (function() {
     if (getICAttribute(elt, 'ic-trigger-on')) {
       // record button or submit input click info
       if(elt.is('form')) {
-        elt.find('input, button').on('click focus', function(e){
+        elt.on('click focus', 'input, button, select', function(e){
           if($(this).is('input[type="submit"], button') && $(this).is("[name]")) {
             elt.data('ic-last-clicked-button', {name:$(this).attr("name"), value:$(this).val()})
           } else {

--- a/src/intercooler.js
+++ b/src/intercooler.js
@@ -1056,7 +1056,7 @@ var Intercooler = Intercooler || (function() {
     if (getICAttribute(elt, 'ic-trigger-on')) {
       // record button or submit input click info
       if(elt.is('form')) {
-        elt.on('click focus', 'input, button, select', function(e){
+        elt.on('click focus', 'input, button, select, textarea', function(e){
           if($(this).is('input[type="submit"], button') && $(this).is("[name]")) {
             elt.data('ic-last-clicked-button', {name:$(this).attr("name"), value:$(this).val()})
           } else {

--- a/test/jQuery1_unit_tests.html
+++ b/test/jQuery1_unit_tests.html
@@ -214,6 +214,38 @@
   </div>
 </div>
 
+<script>
+function eval_test(...args) {
+    return args;
+}
+QUnit.test("Script evaluation", function (assert) {
+  var geval = Intercooler._internal.globalEval;
+  assert.deepEqual(geval("return eval_test()"), [], "Unsafe basic: empty return");
+  assert.deepEqual(geval("return eval_test('a')"), ['a'], "Unsafe basic: return");
+  assert.deepEqual(
+    geval("return a", [['a', 'b']]),
+    "b",
+    "Unsafe args: single return"
+  );
+  assert.deepEqual(
+    geval("return [a, c]", [['a', 'b'], ['c', 'd']]),
+    ["b", "d"],
+    "Unsafe args: multiple return"
+  );
+  assert.deepEqual(geval("eval_test"), [], "Safe: empty return");
+  assert.deepEqual(
+    geval("eval_test", [['a', 'b']]),
+    ["b"],
+    "Safe args: single return"
+  );
+  assert.deepEqual(
+    geval("eval_test", [['a', 'b'], ['c', 'd']]),
+    ["b", "d"],
+    "Safe args: single return"
+  );
+});
+</script>
+
 <div class="row">
   <div class="col-md-12">
     <hr/>
@@ -225,6 +257,7 @@
     </script>
   </div>
 </div>
+
 
 <div id="ic-src-div2" ic-src="/basic_update">Foo</div>
 <script>

--- a/test/jQuery1_unit_tests.html
+++ b/test/jQuery1_unit_tests.html
@@ -2019,6 +2019,35 @@ QUnit.test("Script evaluation", function (assert) {
       });
   </script>
 
+  <form id="no_button_val_on_select" ic-post-to="/no_button_val_on_select">
+    <button id="button_to_lose_focus" onclick="return false" name="button_to_lose_focus" value="button_val">click button</button>
+    <select id="select_to_clear_button_val" name="select_to_clear_button_val">
+      <option value="select_val_1">select 1</option>
+      <option value="select_val_2">select 2</option>
+    </select>
+  </form>
+
+  <script>
+    intercoolerTest("No value included for button after select",
+      function (assert) {
+        $.mockjax({
+          url: "/no_button_val_on_select",
+          response: function(settings) {
+            var params = parseParams(settings.data);
+            assert.equal(params["button_to_lose_focus"], null);
+            assert.equal(params["select_to_clear_button_val"], "select_val_2");
+            return "";
+          }
+        });
+        $("#button_to_lose_focus").click();
+        $("#select_to_clear_button_val").val("select_val_2").click();
+        $("#no_button_val_on_select").submit();
+      },
+      function (assert) {
+        // nothing to do here
+      });
+  </script>
+
   <form id="addCategoryForm" ic-post-to="/categories/create" style="">
     <div class="form-group">
       <input type="text" class="form-control" name="Name" placeholder="Category Name - 'Apparel', 'Drinkware', etc..." required="" value="asdr">

--- a/test/jQuery2_unit_tests.html
+++ b/test/jQuery2_unit_tests.html
@@ -214,6 +214,38 @@
   </div>
 </div>
 
+<script>
+function eval_test(...args) {
+    return args;
+}
+QUnit.test("Script evaluation", function (assert) {
+  var geval = Intercooler._internal.globalEval;
+  assert.deepEqual(geval("return eval_test()"), [], "Unsafe basic: empty return");
+  assert.deepEqual(geval("return eval_test('a')"), ['a'], "Unsafe basic: return");
+  assert.deepEqual(
+    geval("return a", [['a', 'b']]),
+    "b",
+    "Unsafe args: single return"
+  );
+  assert.deepEqual(
+    geval("return [a, c]", [['a', 'b'], ['c', 'd']]),
+    ["b", "d"],
+    "Unsafe args: multiple return"
+  );
+  assert.deepEqual(geval("eval_test"), [], "Safe: empty return");
+  assert.deepEqual(
+    geval("eval_test", [['a', 'b']]),
+    ["b"],
+    "Safe args: single return"
+  );
+  assert.deepEqual(
+    geval("eval_test", [['a', 'b'], ['c', 'd']]),
+    ["b", "d"],
+    "Safe args: single return"
+  );
+});
+</script>
+
 <div class="row">
   <div class="col-md-12">
     <hr/>
@@ -225,6 +257,7 @@
     </script>
   </div>
 </div>
+
 
 <div id="ic-src-div2" ic-src="/basic_update">Foo</div>
 <script>

--- a/test/jQuery2_unit_tests.html
+++ b/test/jQuery2_unit_tests.html
@@ -2019,6 +2019,35 @@ QUnit.test("Script evaluation", function (assert) {
       });
   </script>
 
+  <form id="no_button_val_on_select" ic-post-to="/no_button_val_on_select">
+    <button id="button_to_lose_focus" onclick="return false" name="button_to_lose_focus" value="button_val">click button</button>
+    <select id="select_to_clear_button_val" name="select_to_clear_button_val">
+      <option value="select_val_1">select 1</option>
+      <option value="select_val_2">select 2</option>
+    </select>
+  </form>
+
+  <script>
+    intercoolerTest("No value included for button after select",
+      function (assert) {
+        $.mockjax({
+          url: "/no_button_val_on_select",
+          response: function(settings) {
+            var params = parseParams(settings.data);
+            assert.equal(params["button_to_lose_focus"], null);
+            assert.equal(params["select_to_clear_button_val"], "select_val_2");
+            return "";
+          }
+        });
+        $("#button_to_lose_focus").click();
+        $("#select_to_clear_button_val").val("select_val_2").click();
+        $("#no_button_val_on_select").submit();
+      },
+      function (assert) {
+        // nothing to do here
+      });
+  </script>
+
   <form id="addCategoryForm" ic-post-to="/categories/create" style="">
     <div class="form-group">
       <input type="text" class="form-control" name="Name" placeholder="Category Name - 'Apparel', 'Drinkware', etc..." required="" value="asdr">

--- a/test/unit_tests.html
+++ b/test/unit_tests.html
@@ -2022,6 +2022,35 @@ QUnit.test("Script evaluation", function (assert) {
       });
   </script>
 
+  <form id="no_button_val_on_select" ic-post-to="/no_button_val_on_select">
+    <button id="button_to_lose_focus" onclick="return false" name="button_to_lose_focus" value="button_val">click button</button>
+    <select id="select_to_clear_button_val" name="select_to_clear_button_val">
+      <option value="select_val_1">select 1</option>
+      <option value="select_val_2">select 2</option>
+    </select>
+  </form>
+
+  <script>
+    intercoolerTest("No value included for button after select",
+      function (assert) {
+        $.mockjax({
+          url: "/no_button_val_on_select",
+          response: function(settings) {
+            var params = parseParams(settings.data);
+            assert.equal(params["button_to_lose_focus"], null);
+            assert.equal(params["select_to_clear_button_val"], "select_val_2");
+            return "";
+          }
+        });
+        $("#button_to_lose_focus").click();
+        $("#select_to_clear_button_val").val("select_val_2").click();
+        $("#no_button_val_on_select").submit();
+      },
+      function (assert) {
+        // nothing to do here
+      });
+  </script>
+
   <form id="addCategoryForm" ic-post-to="/categories/create" style="">
     <div class="form-group">
       <input type="text" class="form-control" name="Name" placeholder="Category Name - 'Apparel', 'Drinkware', etc..." required="" value="asdr">

--- a/test/zepto_unit_tests.html
+++ b/test/zepto_unit_tests.html
@@ -2030,6 +2030,35 @@ QUnit.test("Script evaluation", function (assert) {
       });
   </script>
 
+  <form id="no_button_val_on_select" ic-post-to="/no_button_val_on_select">
+    <button id="button_to_lose_focus" onclick="return false" name="button_to_lose_focus" value="button_val">click button</button>
+    <select id="select_to_clear_button_val" name="select_to_clear_button_val">
+      <option value="select_val_1">select 1</option>
+      <option value="select_val_2">select 2</option>
+    </select>
+  </form>
+
+  <script>
+    intercoolerTest("No value included for button after select",
+      function (assert) {
+        $.mockjax({
+          url: "/no_button_val_on_select",
+          response: function(settings) {
+            var params = parseParams(settings.data);
+            assert.equal(params["button_to_lose_focus"], null);
+            assert.equal(params["select_to_clear_button_val"], "select_val_2");
+            return "";
+          }
+        });
+        $("#button_to_lose_focus").click();
+        $("#select_to_clear_button_val").val("select_val_2").click();
+        $("#no_button_val_on_select").submit();
+      },
+      function (assert) {
+        // nothing to do here
+      });
+  </script>
+
   <form id="addCategoryForm" ic-post-to="/categories/create" style="">
     <div class="form-group">
       <input type="text" class="form-control" name="Name" placeholder="Category Name - 'Apparel', 'Drinkware', etc..." required="" value="asdr">

--- a/test/zepto_unit_tests.html
+++ b/test/zepto_unit_tests.html
@@ -225,6 +225,38 @@
   </div>
 </div>
 
+<script>
+function eval_test(...args) {
+    return args;
+}
+QUnit.test("Script evaluation", function (assert) {
+  var geval = Intercooler._internal.globalEval;
+  assert.deepEqual(geval("return eval_test()"), [], "Unsafe basic: empty return");
+  assert.deepEqual(geval("return eval_test('a')"), ['a'], "Unsafe basic: return");
+  assert.deepEqual(
+    geval("return a", [['a', 'b']]),
+    "b",
+    "Unsafe args: single return"
+  );
+  assert.deepEqual(
+    geval("return [a, c]", [['a', 'b'], ['c', 'd']]),
+    ["b", "d"],
+    "Unsafe args: multiple return"
+  );
+  assert.deepEqual(geval("eval_test"), [], "Safe: empty return");
+  assert.deepEqual(
+    geval("eval_test", [['a', 'b']]),
+    ["b"],
+    "Safe args: single return"
+  );
+  assert.deepEqual(
+    geval("eval_test", [['a', 'b'], ['c', 'd']]),
+    ["b", "d"],
+    "Safe args: single return"
+  );
+});
+</script>
+
 <div class="row">
   <div class="col-md-12">
     <hr/>
@@ -236,6 +268,7 @@
     </script>
   </div>
 </div>
+
 
 <div id="ic-src-div2" ic-src="/basic_update">Foo</div>
 <script>


### PR DESCRIPTION
This fixes #217.

Please note that there are two commits. The first one is just regenerating *_unit_tests.html to include a test that someone else had previously added to unit_tests.html ("Script evaluation"), and the second one adds a single new test ("No value included for button after select") and fixes the code to make it pass.
