### PR TITLE
Implement new Fix IDs feature with ic-fix-ids attribute.

### DIFF
--- a/src/intercooler.js
+++ b/src/intercooler.js
@@ -1375,7 +1375,7 @@ var Intercooler = Intercooler || (function() {
   }
 
   function walkTree(elt, filter) {
-    return $(elt).filter(filter).add(elt.find(filter));
+    return elt.filter(filter).add(elt.find(filter));
   }
 
   function fixIDs(contentToSwap) {

--- a/src/intercooler.js
+++ b/src/intercooler.js
@@ -1281,6 +1281,10 @@ var Intercooler = Intercooler || (function() {
 
       var contentToSwap = maybeFilter(responseContent, closestAttrValue(elt, 'ic-select-from-response'));
 
+      if (closestAttrValue(elt, 'ic-fix-ids') == "true") {
+        fixIDs(contentToSwap);
+      }
+
       var doSwap = function() {
         if (closestAttrValue(elt, 'ic-replace-target') == "true") {
           try {
@@ -1364,10 +1368,40 @@ var Intercooler = Intercooler || (function() {
       asQuery = $($.parseHTML(newContent, null, true));
     }
     if (filter) {
-      return asQuery.filter(filter).add(asQuery.find(filter)).contents();
+      return walkTree(asQuery, filter).contents();
     } else {
       return asQuery;
     }
+  }
+
+  function walkTree(elt, filter) {
+    return $(elt).filter(filter).add(elt.find(filter));
+  }
+
+  function fixIDs(contentToSwap) {
+    var fixedIDs = {};
+    walkTree(contentToSwap, "[id]").each(function() {
+      var originalID = $(this).attr("id");
+      var fixedID;
+      do {
+        fixedID = "ic-fixed-id-" + uuid();
+      } while ($("#" + fixedID).length > 0);
+      fixedIDs[originalID] = fixedID;
+      $(this).attr("id", fixedID);
+    });
+    walkTree(contentToSwap, "label[for]").each(function () {
+      var originalID = $(this).attr("for");
+      $(this).attr("for", fixedIDs[originalID] || originalID);
+    });
+    walkTree(contentToSwap, "*").each(function () {
+      $.each(this.attributes, function () {
+        if (this.value.indexOf("#") !== -1) {
+          this.value = this.value.replace(/#([-_A-Za-z0-9]+)/g, function(match, originalID) {
+            return "#" + (fixedIDs[originalID] || originalID);
+          });
+        }
+      })
+    });
   }
 
   function getStyleTarget(elt) {

--- a/test/jQuery1_unit_tests.html
+++ b/test/jQuery1_unit_tests.html
@@ -2174,6 +2174,51 @@
       });
   </script>
 
+  <div id="prototype-with-ids-to-fix" class="ic-ignore">
+    <div id="first-id-to-fix"></div>
+    <a href="#first-id-to-fix"></a>
+    <div ic-get-from="#first-id-to-fix"></div>
+    <div>
+      <input id="second-id-to-fix"/>
+      <label for="second-id-to-fix"></label>
+    </div>
+    <div data-fix-ids-here-too="bla bla#first-id-to-fix#second-id-to-fix;etc"></div>
+    <div data-not-here-because-longer-id="#second-id-to-fix-not"></div>
+    <div ic-get-from="#id-of-something-outside"></div>
+  </div>
+  <div id="id-of-something-outside"></div>
+  <div id="target-for-fixed-ids" ic-get-from="#prototype-with-ids-to-fix" ic-fix-ids="true"></div>
+  <script>
+    intercoolerTest("Fix IDs in swapped content if ic-fix-ids is specified",
+      function (assert) {
+        if ($.zepto) {
+          $.mockjax({
+            url: "#prototype-with-ids-to-fix",
+            response: function (settings) {
+              this.responseText = $("#prototype-with-ids-to-fix").html();
+            }
+          });
+        }
+        $("#target-for-fixed-ids").click();
+      },
+      function (assert) {
+        var children = $("#target-for-fixed-ids").children();
+        var firstFixedId = $(children[0]).attr("id");
+        var secondFixedId = $(children[3]).find("input").attr("id");
+        assert.notEqual(firstFixedId, "first-id-to-fix");
+        assert.notEqual(secondFixedId, "second-id-to-fix");
+        assert.notEqual(firstFixedId, secondFixedId);
+        assert.strictEqual($("#" + firstFixedId)[0], children[0]);
+        assert.strictEqual($("#" + secondFixedId).parent()[0], children[3]);
+        assert.equal($(children[1]).attr("href"), "#" + firstFixedId);
+        assert.equal($(children[2]).attr("ic-get-from"), "#" + firstFixedId);
+        assert.equal($(children[3]).find("label").attr("for"), secondFixedId);
+        assert.equal($(children[4]).attr("data-fix-ids-here-too"), "bla bla#" + firstFixedId + "#" + secondFixedId + ";etc");
+        assert.equal($(children[5]).attr("data-not-here-because-longer-id"), "#second-id-to-fix-not");
+        assert.equal($(children[6]).attr("ic-get-from"), "#id-of-something-outside");
+      });
+  </script>
+
 </div>
 </body>
 </html>

--- a/test/jQuery1_unit_tests.html
+++ b/test/jQuery1_unit_tests.html
@@ -2211,11 +2211,11 @@
         assert.strictEqual($("#" + firstFixedId)[0], children[0]);
         assert.strictEqual($("#" + secondFixedId).parent()[0], children[3]);
         assert.equal($(children[1]).attr("href"), "#" + firstFixedId);
-        assert.equal($(children[2]).attr("ic-get-from"), "#" + firstFixedId);
+        assert.equal($(children[2]).attr(fixAttrName("ic-get-from")), "#" + firstFixedId);
         assert.equal($(children[3]).find("label").attr("for"), secondFixedId);
         assert.equal($(children[4]).attr("data-fix-ids-here-too"), "bla bla#" + firstFixedId + "#" + secondFixedId + ";etc");
         assert.equal($(children[5]).attr("data-not-here-because-longer-id"), "#second-id-to-fix-not");
-        assert.equal($(children[6]).attr("ic-get-from"), "#id-of-something-outside");
+        assert.equal($(children[6]).attr(fixAttrName("ic-get-from")), "#id-of-something-outside");
       });
   </script>
 

--- a/test/jQuery2_unit_tests.html
+++ b/test/jQuery2_unit_tests.html
@@ -2174,6 +2174,51 @@
       });
   </script>
 
+  <div id="prototype-with-ids-to-fix" class="ic-ignore">
+    <div id="first-id-to-fix"></div>
+    <a href="#first-id-to-fix"></a>
+    <div ic-get-from="#first-id-to-fix"></div>
+    <div>
+      <input id="second-id-to-fix"/>
+      <label for="second-id-to-fix"></label>
+    </div>
+    <div data-fix-ids-here-too="bla bla#first-id-to-fix#second-id-to-fix;etc"></div>
+    <div data-not-here-because-longer-id="#second-id-to-fix-not"></div>
+    <div ic-get-from="#id-of-something-outside"></div>
+  </div>
+  <div id="id-of-something-outside"></div>
+  <div id="target-for-fixed-ids" ic-get-from="#prototype-with-ids-to-fix" ic-fix-ids="true"></div>
+  <script>
+    intercoolerTest("Fix IDs in swapped content if ic-fix-ids is specified",
+      function (assert) {
+        if ($.zepto) {
+          $.mockjax({
+            url: "#prototype-with-ids-to-fix",
+            response: function (settings) {
+              this.responseText = $("#prototype-with-ids-to-fix").html();
+            }
+          });
+        }
+        $("#target-for-fixed-ids").click();
+      },
+      function (assert) {
+        var children = $("#target-for-fixed-ids").children();
+        var firstFixedId = $(children[0]).attr("id");
+        var secondFixedId = $(children[3]).find("input").attr("id");
+        assert.notEqual(firstFixedId, "first-id-to-fix");
+        assert.notEqual(secondFixedId, "second-id-to-fix");
+        assert.notEqual(firstFixedId, secondFixedId);
+        assert.strictEqual($("#" + firstFixedId)[0], children[0]);
+        assert.strictEqual($("#" + secondFixedId).parent()[0], children[3]);
+        assert.equal($(children[1]).attr("href"), "#" + firstFixedId);
+        assert.equal($(children[2]).attr("ic-get-from"), "#" + firstFixedId);
+        assert.equal($(children[3]).find("label").attr("for"), secondFixedId);
+        assert.equal($(children[4]).attr("data-fix-ids-here-too"), "bla bla#" + firstFixedId + "#" + secondFixedId + ";etc");
+        assert.equal($(children[5]).attr("data-not-here-because-longer-id"), "#second-id-to-fix-not");
+        assert.equal($(children[6]).attr("ic-get-from"), "#id-of-something-outside");
+      });
+  </script>
+
 </div>
 </body>
 </html>

--- a/test/jQuery2_unit_tests.html
+++ b/test/jQuery2_unit_tests.html
@@ -2211,11 +2211,11 @@
         assert.strictEqual($("#" + firstFixedId)[0], children[0]);
         assert.strictEqual($("#" + secondFixedId).parent()[0], children[3]);
         assert.equal($(children[1]).attr("href"), "#" + firstFixedId);
-        assert.equal($(children[2]).attr("ic-get-from"), "#" + firstFixedId);
+        assert.equal($(children[2]).attr(fixAttrName("ic-get-from")), "#" + firstFixedId);
         assert.equal($(children[3]).find("label").attr("for"), secondFixedId);
         assert.equal($(children[4]).attr("data-fix-ids-here-too"), "bla bla#" + firstFixedId + "#" + secondFixedId + ";etc");
         assert.equal($(children[5]).attr("data-not-here-because-longer-id"), "#second-id-to-fix-not");
-        assert.equal($(children[6]).attr("ic-get-from"), "#id-of-something-outside");
+        assert.equal($(children[6]).attr(fixAttrName("ic-get-from")), "#id-of-something-outside");
       });
   </script>
 

--- a/test/unit_tests.html
+++ b/test/unit_tests.html
@@ -2247,11 +2247,11 @@ QUnit.test("Script evaluation", function (assert) {
         assert.strictEqual($("#" + firstFixedId)[0], children[0]);
         assert.strictEqual($("#" + secondFixedId).parent()[0], children[3]);
         assert.equal($(children[1]).attr("href"), "#" + firstFixedId);
-        assert.equal($(children[2]).attr("ic-get-from"), "#" + firstFixedId);
+        assert.equal($(children[2]).attr(fixAttrName("ic-get-from")), "#" + firstFixedId);
         assert.equal($(children[3]).find("label").attr("for"), secondFixedId);
         assert.equal($(children[4]).attr("data-fix-ids-here-too"), "bla bla#" + firstFixedId + "#" + secondFixedId + ";etc");
         assert.equal($(children[5]).attr("data-not-here-because-longer-id"), "#second-id-to-fix-not");
-        assert.equal($(children[6]).attr("ic-get-from"), "#id-of-something-outside");
+        assert.equal($(children[6]).attr(fixAttrName("ic-get-from")), "#id-of-something-outside");
       });
   </script>
 

--- a/test/unit_tests.html
+++ b/test/unit_tests.html
@@ -2210,6 +2210,51 @@ QUnit.test("Script evaluation", function (assert) {
       });
   </script>
 
+  <div id="prototype-with-ids-to-fix" class="ic-ignore">
+    <div id="first-id-to-fix"></div>
+    <a href="#first-id-to-fix"></a>
+    <div ic-get-from="#first-id-to-fix"></div>
+    <div>
+      <input id="second-id-to-fix"/>
+      <label for="second-id-to-fix"></label>
+    </div>
+    <div data-fix-ids-here-too="bla bla#first-id-to-fix#second-id-to-fix;etc"></div>
+    <div data-not-here-because-longer-id="#second-id-to-fix-not"></div>
+    <div ic-get-from="#id-of-something-outside"></div>
+  </div>
+  <div id="id-of-something-outside"></div>
+  <div id="target-for-fixed-ids" ic-get-from="#prototype-with-ids-to-fix" ic-fix-ids="true"></div>
+  <script>
+    intercoolerTest("Fix IDs in swapped content if ic-fix-ids is specified",
+      function (assert) {
+        if ($.zepto) {
+          $.mockjax({
+            url: "#prototype-with-ids-to-fix",
+            response: function (settings) {
+              this.responseText = $("#prototype-with-ids-to-fix").html();
+            }
+          });
+        }
+        $("#target-for-fixed-ids").click();
+      },
+      function (assert) {
+        var children = $("#target-for-fixed-ids").children();
+        var firstFixedId = $(children[0]).attr("id");
+        var secondFixedId = $(children[3]).find("input").attr("id");
+        assert.notEqual(firstFixedId, "first-id-to-fix");
+        assert.notEqual(secondFixedId, "second-id-to-fix");
+        assert.notEqual(firstFixedId, secondFixedId);
+        assert.strictEqual($("#" + firstFixedId)[0], children[0]);
+        assert.strictEqual($("#" + secondFixedId).parent()[0], children[3]);
+        assert.equal($(children[1]).attr("href"), "#" + firstFixedId);
+        assert.equal($(children[2]).attr("ic-get-from"), "#" + firstFixedId);
+        assert.equal($(children[3]).find("label").attr("for"), secondFixedId);
+        assert.equal($(children[4]).attr("data-fix-ids-here-too"), "bla bla#" + firstFixedId + "#" + secondFixedId + ";etc");
+        assert.equal($(children[5]).attr("data-not-here-because-longer-id"), "#second-id-to-fix-not");
+        assert.equal($(children[6]).attr("ic-get-from"), "#id-of-something-outside");
+      });
+  </script>
+
 </div>
 </body>
 </html>

--- a/test/zepto_unit_tests.html
+++ b/test/zepto_unit_tests.html
@@ -2222,11 +2222,11 @@
         assert.strictEqual($("#" + firstFixedId)[0], children[0]);
         assert.strictEqual($("#" + secondFixedId).parent()[0], children[3]);
         assert.equal($(children[1]).attr("href"), "#" + firstFixedId);
-        assert.equal($(children[2]).attr("ic-get-from"), "#" + firstFixedId);
+        assert.equal($(children[2]).attr(fixAttrName("ic-get-from")), "#" + firstFixedId);
         assert.equal($(children[3]).find("label").attr("for"), secondFixedId);
         assert.equal($(children[4]).attr("data-fix-ids-here-too"), "bla bla#" + firstFixedId + "#" + secondFixedId + ";etc");
         assert.equal($(children[5]).attr("data-not-here-because-longer-id"), "#second-id-to-fix-not");
-        assert.equal($(children[6]).attr("ic-get-from"), "#id-of-something-outside");
+        assert.equal($(children[6]).attr(fixAttrName("ic-get-from")), "#id-of-something-outside");
       });
   </script>
 

--- a/test/zepto_unit_tests.html
+++ b/test/zepto_unit_tests.html
@@ -2185,6 +2185,51 @@
       });
   </script>
 
+  <div id="prototype-with-ids-to-fix" class="ic-ignore">
+    <div id="first-id-to-fix"></div>
+    <a href="#first-id-to-fix"></a>
+    <div ic-get-from="#first-id-to-fix"></div>
+    <div>
+      <input id="second-id-to-fix"/>
+      <label for="second-id-to-fix"></label>
+    </div>
+    <div data-fix-ids-here-too="bla bla#first-id-to-fix#second-id-to-fix;etc"></div>
+    <div data-not-here-because-longer-id="#second-id-to-fix-not"></div>
+    <div ic-get-from="#id-of-something-outside"></div>
+  </div>
+  <div id="id-of-something-outside"></div>
+  <div id="target-for-fixed-ids" ic-get-from="#prototype-with-ids-to-fix" ic-fix-ids="true"></div>
+  <script>
+    intercoolerTest("Fix IDs in swapped content if ic-fix-ids is specified",
+      function (assert) {
+        if ($.zepto) {
+          $.mockjax({
+            url: "#prototype-with-ids-to-fix",
+            response: function (settings) {
+              this.responseText = $("#prototype-with-ids-to-fix").html();
+            }
+          });
+        }
+        $("#target-for-fixed-ids").click();
+      },
+      function (assert) {
+        var children = $("#target-for-fixed-ids").children();
+        var firstFixedId = $(children[0]).attr("id");
+        var secondFixedId = $(children[3]).find("input").attr("id");
+        assert.notEqual(firstFixedId, "first-id-to-fix");
+        assert.notEqual(secondFixedId, "second-id-to-fix");
+        assert.notEqual(firstFixedId, secondFixedId);
+        assert.strictEqual($("#" + firstFixedId)[0], children[0]);
+        assert.strictEqual($("#" + secondFixedId).parent()[0], children[3]);
+        assert.equal($(children[1]).attr("href"), "#" + firstFixedId);
+        assert.equal($(children[2]).attr("ic-get-from"), "#" + firstFixedId);
+        assert.equal($(children[3]).find("label").attr("for"), secondFixedId);
+        assert.equal($(children[4]).attr("data-fix-ids-here-too"), "bla bla#" + firstFixedId + "#" + secondFixedId + ";etc");
+        assert.equal($(children[5]).attr("data-not-here-because-longer-id"), "#second-id-to-fix-not");
+        assert.equal($(children[6]).attr("ic-get-from"), "#id-of-something-outside");
+      });
+  </script>
+
 </div>
 </body>
 </html>

--- a/www/attributes/ic-fix-ids.html
+++ b/www/attributes/ic-fix-ids.html
@@ -1,0 +1,31 @@
+---
+layout: default
+nav: attributes > ic-fix-ids
+---
+
+<div class="container">
+
+  <div class="row">
+    <div class="col-md-12">
+
+      <h2><code>ic-fix-ids</code> - The Fix IDs Attribute</h2>
+
+      <h3>Summary</h3>
+
+      <p>The <code>ic-fix-ids</code> attribute tells Intercooler to replace the IDs of any added elements
+        with globally unique IDs so that they don't conflict with any existing IDs on the page.</p>
+
+      <h3>Syntax</h3>
+
+      <p>The value of the <code>ic-fix-ids</code> attribute should be "true", or it should be omitted entirely.</p>
+
+      <p>This attribute may be placed on parent elements, allowing you to specify behavior across
+        multiple elements.</p>
+
+      <h3>Dependencies</h3>
+
+      <p><code>ic-fix-ids</code> attribute has no effect on dependencies.</p>
+
+    </div>
+  </div>
+</div>

--- a/www/reference.html
+++ b/www/reference.html
@@ -75,6 +75,12 @@ nav: attributes > all
             </tr>
 
             <tr>
+              <td><a href="/attributes/ic-fix-ids.html">ic-fix-ids</a></td>
+              <td>This attribute tells Intercooler to replace the IDs of any added elements with globally unique IDs
+                so that they don't conflict with any existing IDs on the page.</td>
+            </tr>
+
+            <tr>
               <td><a href="/attributes/ic-get-from.html">ic-get-from</a></td>
               <td>This attribute allows you to bind the "action" of an element to a given URL. Once it is bound, when an
                 "action" occurs (e.g. clicking a button) Intercooler will issue


### PR DESCRIPTION
Description from the included docs: _The `ic-fix-ids` attribute tells Intercooler to replace the IDs of any added elements with globally unique IDs so that they don't conflict with any existing IDs on the page._

I'm planning to use this together with a local prototype rendered with repeatable form fields. I've currently got it to work without any IDs inside the prototype elements, but it's a little messy and means I can't use `<label for='...'>`. With this new `ic-fix-ids` feature, I'll be able to put IDs on the fields, simplify the mechanism, and attach labels for better usability/accessibility.

Please feel free to critique the implementation heavily, including the name of the attribute. The code traverses every single attribute of every element being swapped in, including descendants, and I'm not really familiar with the performance implications of some of these jQuery calls. The HTML involved in my own use case is small enough that I'm not worried about it.

It also may be overzealous to try to replace every occurrence of `#foo` found in any attribute; we could try to be more selective, or only replace when it appears as the entire attribute value. There's a slight chance that someone might use an ID that also looks like a CSS color (e.g. `#abcdef`), but that seems unlikely enough, and easy enough to work around, that I'm not too worried.

I've run all 4 versions of the unit tests against Chrome 60 (Mac), Safari 10 (Mac), and Firefox 36 (Win). The `if ($.zepto)` clause in the new test just works around the fact that Zepto doesn't support local prototype content; the `ic-fix-ids` feature isn't actually dependent on the content coming from a local prototype, so that's not central to what's being tested.