### PR TITLE
Reference: fix ic-scroll-to-target description

### DIFF
--- a/www/reference.html
+++ b/www/reference.html
@@ -250,7 +250,9 @@ nav: attributes > all
 
             <tr>
               <td><a href="/attributes/ic-scroll-to-target.html">ic-scroll-to-target</a></td>
-              <td>An offset in pixels to adjust the scroll position when using the <code>ic-scroll-to-target</code> attribute</td>
+              <td>If this attribute is set to "true", the target element of the intercooler request will have its
+                top scrolled into the viewport if it is not visible. The scroll destination can be adjusted using
+                the <code>ic-scroll-offset</code> attribute.</td>
             </tr>
 
             <tr>


### PR DESCRIPTION
`ic-scroll-to-target` didn't have the correct description, it was just a
duplicate of `ic-scroll-offset`'s.

---

Definitely free to adjust the wording if you don't like it, I just tried to copy how some of the other ones were written.