### PR TITLE
Fix check for missing ic-sse-src element.

### DIFF
--- a/src/intercooler.js
+++ b/src/intercooler.js
@@ -1076,7 +1076,7 @@ var Intercooler = Intercooler || (function() {
         if(triggerOn[0].indexOf("sse:") == 0) {
           //Server-sent event, find closest event source and register for it
           var sourceElt = elt.closest(getICAttributeSelector('ic-sse-src'));
-          if(sourceElt) {
+          if(sourceElt.length > 0) {
             registerSSE(sourceElt, triggerOn[0].substr(4))
           }
         } else {

--- a/test/unit_tests.html
+++ b/test/unit_tests.html
@@ -2187,6 +2187,37 @@ QUnit.test("Script evaluation", function (assert) {
       });
   </script>
 
+  <div id="sse-6" ic-sse-src="/foo">
+    <span id="sse-6-inner" ic-get-from="/sse_replace_req" ic-trigger-on="sse:foo" ic-replace-target="true"></span>
+  </div>
+  <script>
+    // This test fails if you see a warning in the console of the form:
+    //
+    // Intercooler Error : Error during content swap : TypeError: Cannot read
+    //   property 'addEventListener' of undefined
+    // TypeError: Cannot read property 'addEventListener' of undefined
+    //     at registerSSE (...)
+    //     at handleTriggerOn (...)
+    //     ...
+    intercoolerTest("Server Sent Event trigger handles missing ic-sse-src element", function(assert) {
+        $.mockjax({
+          url: "/sse_replace_req",
+          responseText: "<span id='sse-6-inner' ic-trigger-on='sse:foo'>foo</span>"
+        });
+        var mockSource = $("#sse-6").data("ic-event-sse-source");
+        assert.equal("", $("#sse-6-inner").html());
+
+        // Two events will cause a race between two requests, and one of the
+        // resulting <span>s will be removed from the DOM, thereby causing an
+        // ic-sse-src element to not be found for it.
+        mockSource.fireEvent("foo", "");
+        mockSource.fireEvent("foo", "");
+      },
+      function(assert) {
+        assert.equal("foo", $("#sse-6-inner").html());
+      });
+  </script>
+
   <div id="anchor-regression-div">
       <a id="anchor-regression-a" class="button button--primary" ic-post-to="/anchor_regression?issue=1" ic-replace-target="true">
           <span>Click Me!</span>


### PR DESCRIPTION
Intercooler looks for a parent element with an `ic-sse-src` attribute when processing a trigger of the form `ic-trigger-on="sse:..."`. If the same SSE event is triggered twice in short succession with `ic-replace-target="true"`, this parent element may not be found because the target got removed from the DOM, causing a console message of the following form:

```
Intercooler Error : Error during content swap : TypeError: Cannot read property 'addEventListener' of undefined
TypeError: Cannot read property 'addEventListener' of undefined
    at registerSSE (src/intercooler.js:1028:15)
    at handleTriggerOn (src/intercooler.js:1080:13)
    at processTriggerOn (src/intercooler.js:787:7)
    at processNodes (src/intercooler.js:717:7)
    at doSwap (src/intercooler.js:1309:11)
    at src/intercooler.js:1352:11
```

There's currently a check to see if the parent exists, but it's buggy due to the nature of jQuery objects. The fix is fairly trivial.

Note that this doesn't cause the functionality to break in any way; it just incurs a superfluous log to the console, as shown above. I added a test that triggers the console error, and successfully removed it with my changes, but the test always passes since the functionality isn't incorrect. Let me know if there's a better way you'd like me to test this.

A simpler way to cause the issue would be just have an element with `ic-trigger-on="sse:..."`, but no parent element with an `ic-sse-src` attribute. I thought I'd reproduce my exact case here, but we could also test it in that way.