### PR TITLE
show current year in footer

### DIFF
--- a/www/_config.yml
+++ b/www/_config.yml
@@ -5,3 +5,4 @@ exclude:
   - Gemfile
   - Gemfile.lock
   - Capfile
+  - vendor

--- a/www/_layouts/default.html
+++ b/www/_layouts/default.html
@@ -116,7 +116,7 @@
   <hr>
   <footer>
     <p>
-      &copy; <a href="http://intercoolerjs.org">IntercoolerJS.org</a> 2013-2017
+      &copy; <a href="http://intercoolerjs.org">IntercoolerJS.org</a> 2013-{{ 'now' | date: "%Y" }}
       <span class="pull-right"><em>Sponsored By <a rel="nofollow" href="http://www.leaddyno.com">LeadDyno</a> & <a href="https://www.maxcdn.com/">MaxCDN</a></em></span>
     </p>
   </footer>


### PR DESCRIPTION
* Copyright `2013-{{ 'now' | date: "%Y" }}` in footer
* Jekyll config: ignore `vendor` folder. This was caused by me running into this issue when building the site locally: https://github.com/erayaydin/jekyll-bulma/issues/6
I assume it's generally best practice to ignore the `vendor` dir.